### PR TITLE
Upgrade eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-brunch",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Adds eslint support to brunch.",
   "author": "Aurélien David <adavid@jolicode.com>",
   "homepage": "https://github.com/spyl94/eslint-brunch",
@@ -14,9 +14,9 @@
     "test": "node_modules/.bin/mocha --require test/common.js"
   },
   "dependencies": {
-    "babel-eslint": "^3.1.23",
-    "chalk": "^1.0.0",
-    "eslint": "^0.24.1",
-    "pluralize": "^1.1.2"
+    "babel-eslint": "^3.1.30",
+    "chalk": "^1.1.1",
+    "eslint": "^1.7.1",
+    "pluralize": "^1.2.1"
   }
 }


### PR DESCRIPTION
Ran `npm update` to fetch latest dependencies, which brings in eslint 1.x. 
