### PR TITLE
Support Windows with default pattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ class ESLinter {
     this.config = brunchConfig || {};
     const config = brunchConfig.plugins && brunchConfig.plugins.eslint || {};
     this.warnOnly = config.warnOnly != null ? config.warnOnly : true;
-    this.pattern = config.pattern || /^app\/.*\.js?$/;
+    this.pattern = config.pattern || /^app[\/\\].*\.js?$/;
 
     var useConfig;
     try {


### PR DESCRIPTION
Support both types of slashes in default pattern, so it works on Windows with default conventions.
