### PR TITLE
Move eslint to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "pluralize": "~1.2.1"
+  },
+  "devDependencies": {
+    "eslint": "~2.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
   "scripts": {
     "test": "node_modules/.bin/eslint index.js"
   },
+  "peerDependencies": {
+    "eslint": "~2.x"
+  },
   "dependencies": {
     "chalk": "^1.1.3",
-    "eslint": "~2.5.0",
     "pluralize": "~1.2.1"
   }
 }


### PR DESCRIPTION
With the hard-dependency of eslint 2.5, eslint-brunch ties users to eslint-configs that are tied to that version. By making it a peer dependency, users can choose their own combination of configurations and plugins.
