### PR TITLE
Fixes for #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Adds [ESLint](http://eslint.org) support to [brunch](http://brunch.io).
 ## Usage
 Install the plugin via npm with `npm install --save eslint eslint-brunch`.
 
-Configuration settings can be set in any acceptable `.eslintrc.*` [configration file formats](http://eslint.org/docs/user-guide/configuring#configuration-file-formats). If no configuration file can be found, this plugin will fallback to default ESLint options.
+Configuration settings can be set in any acceptable `.eslintrc.*` [configuration file formats](http://eslint.org/docs/user-guide/configuring#configuration-file-formats). If no configuration file can be found, this plugin will fallback to default ESLint options.
 
 ## Options
 
@@ -13,14 +13,19 @@ config = {
   plugins: {
     eslint: {
       pattern: /^app\/.*\.js?$/,
-      warnOnly: yes,
+      warnOnly: true,
       config: {rules: {'array-callback-return': 'warn'}}
     }
   }
 }
 ```
 
-Every sub-option (`pattern`, `warnOnly`) is optional.
+| Option     | Type    | Optional? | Description                                                                                                 |
+|------------|---------|:---------:|-------------------------------------------------------------------------------------------------------------|
+| `pattern`  | RegExp  | Yes       | Pattern of filepaths to be processed ([docs](http://brunch.io/docs/plugins#property-pattern-)).             |
+| `warnOnly` | Boolean | Yes       | Use `warn` logging level instead of `error`.                                                                |
+| `config`   | Object  | Yes       | Options to pass to the ESLint engine ([docs](http://eslint.org/docs/developer-guide/nodejs-api#cliengine)). |
+
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -10,10 +10,8 @@ class ESLinter {
     this.config   = (brunchConfig && brunchConfig.plugins && brunchConfig.plugins.eslint) || {};
     this.warnOnly = (this.config.warnOnly === true);
     this.pattern  = this.config.pattern || /^app[\/\\].*\.js?$/;
-
-    const engineConfig = {};
-
-    this.linter = new CLIEngine(engineConfig);
+    this.engineOptions = this.config.config || {};
+    this.linter = new CLIEngine(this.engineOptions);
   }
 
   lint(data, path) {

--- a/index.js
+++ b/index.js
@@ -1,15 +1,14 @@
 'use strict';
 
 const colors = require('ansicolors');
-const fs = require('fs');
 const pluralize = require('pluralize');
 const CLIEngine = require('eslint').CLIEngine;
 
 class ESLinter {
   constructor(brunchConfig) {
-    this.config   = (brunchConfig && brunchConfig.plugins && brunchConfig.plugins.eslint) || {};
+    this.config = (brunchConfig && brunchConfig.plugins && brunchConfig.plugins.eslint) || {};
     this.warnOnly = (this.config.warnOnly === true);
-    this.pattern  = this.config.pattern || /^app[\/\\].*\.js?$/;
+    this.pattern = this.config.pattern || /^app[\/\\].*\.js?$/;
     this.engineOptions = this.config.config || {};
     this.linter = new CLIEngine(this.engineOptions);
   }

--- a/index.js
+++ b/index.js
@@ -7,10 +7,9 @@ const CLIEngine = require('eslint').CLIEngine;
 
 class ESLinter {
   constructor(brunchConfig) {
-    this.config = brunchConfig || {};
-    const config = brunchConfig.plugins && brunchConfig.plugins.eslint || {};
-    this.warnOnly = config.warnOnly != null ? config.warnOnly : true;
-    this.pattern = config.pattern || /^app[\/\\].*\.js?$/;
+    this.config   = (brunchConfig && brunchConfig.plugins && brunchConfig.plugins.eslint) || {};
+    this.warnOnly = (this.config.warnOnly === true);
+    this.pattern  = this.config.pattern || /^app[\/\\].*\.js?$/;
 
     const engineConfig = {};
 

--- a/index.js
+++ b/index.js
@@ -5,8 +5,6 @@ const fs = require('fs');
 const pluralize = require('pluralize');
 const CLIEngine = require('eslint').CLIEngine;
 
-const configFilePrefix = '.eslintrc';
-
 class ESLinter {
   constructor(brunchConfig) {
     this.config = brunchConfig || {};
@@ -14,32 +12,7 @@ class ESLinter {
     this.warnOnly = config.warnOnly != null ? config.warnOnly : true;
     this.pattern = config.pattern || /^app[\/\\].*\.js?$/;
 
-    var useConfig;
-    try {
-      useConfig = fs.readdirSync(process.cwd())
-        .filter((filename) => filename.startsWith(configFilePrefix))
-        .filter((configFile) => {
-          try {
-            return fs.statSync(configFile).isFile();
-          } catch (_error) {
-            const e = _error.toString().replace('Error: ENOENT, ', '');
-            console.warn(`${configFile} read error: ${e}`);
-            return false;
-          }
-        })
-        .length > 0;
-    } catch (_error) {
-      useConfig = false;
-    }
-
-    if (useConfig === false) {
-      if (typeof config.config === 'object') {
-        useConfig = config.config;
-      } else {
-        // console.warn(`no usable .eslintrc.* file can be found.\nESLint will run with default options.`);
-      }
-    }
-    const engineConfig = { useEslintrc: useConfig };
+    const engineConfig = {};
 
     this.linter = new CLIEngine(engineConfig);
   }


### PR DESCRIPTION
- [x] Allow to load `.eslintrc`s [in order](https://github.com/eslint/eslint/blob/master/lib/config/config-file.js)
- [x] Allow to load `package.json`'s eslint field

These are implemented in 2389f92. There's no need for the plugin to manually search for an `.eslintrc` config file in the current working directory. [`CLIEngine.executeOnText()`](http://eslint.org/docs/developer-guide/nodejs-api#executeontext) _"will assume that the text is a file in the current working directory, and so will still obey any `.eslintrc` and `.eslintignore` files that may be present."_ So any [configuration files](http://eslint.org/docs/user-guide/configuring#configuration-file-formats) in the current working directory will be automatically loaded by ESLint:
- `.eslintrc.js`
- `.eslintrc.yaml`
- `.eslintrc.yml`
- `.eslintrc.json`
- `.eslintrc`
- `package.json`

---
- [x] Allow to read brunch config's config field

The incorrect implementation was removed in 2389f92, and the correct implementation was added in c96a71d.
