### PR TITLE
Improve logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# eslint-brunch 3.10.0
+* Improves the logging format, with a style based on
+  [ESLint's default "stylish" formatter](http://eslint.org/docs/user-guide/formatters/#stylish)
+* Bug fix: if ESLint only reported warnings for a file (no errors),
+  then those warnings were silently discarded
+
+# eslint-brunch 3.9.1
+* Requires ESLint as a dependency instead of a peerDependency
+
+# eslint-brunch 3.9.0
+* Allows ESLint to automatically find and load all
+  [configuration files](http://eslint.org/docs/user-guide/configuring#using-configuration-files)
+  including `package.json`
+* Implements `config` plugin option, for configuring
+  [ESLint's engine](http://eslint.org/docs/developer-guide/nodejs-api#cliengine)
+
+# eslint-brunch 3.8.0
+* Uses [`ansicolors`](https://www.npmjs.com/package/ansicolors) instead of
+  [`chalk`](https://www.npmjs.com/package/chalk) for terminal colors
+
 # eslint-brunch 3.7.0
 * Allowed eslint 2.x and 3.x in peerDependencies
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ class ESLinter {
   lint(data, path) {
     const result = this.linter.executeOnText(data, path).results[0];
     const errorCount = result.errorCount;
-    if (errorCount === 0) {
+    const warningCount = result.warningCount;
+    if (errorCount === 0 && warningCount === 0) {
       return Promise.resolve();
     }
     const errorMsg = result.messages.map(error => {

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ class ESLinter {
     if (this.warnOnly) {
       msg = `warn: ${msg}`;
     }
-    return (msg ? Promise.reject(msg) : Promise.resolve());
+    return Promise.reject(msg);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,40 @@ const colors = require('ansicolors');
 const pluralize = require('pluralize');
 const CLIEngine = require('eslint').CLIEngine;
 
+var padString = function(input, minLength, right) {
+  var paddingLength = Math.max(0, minLength - input.length);
+  var padding = ' '.repeat(paddingLength);
+  return (right ? (padding + input) : (input + padding));
+};
+
+var formatSeverity = function(severity) {
+  if (severity === 1) {
+    return colors.yellow('warning');
+  }
+  if (severity === 2) {
+    return colors.red('error');
+  }
+  return '';
+};
+
+var formatErrors = function(errors) {
+  var maxLengths = { line: 6, column: 3, severity: 0, message: 0 };
+  errors.forEach((error) => {
+    maxLengths.severity = Math.max(maxLengths.severity, formatSeverity(error.severity).length);
+    maxLengths.message = Math.max(maxLengths.message, error.message.length);
+  });
+  var formattedLines = errors.map((error) =>
+    colors.cyan(
+        padString(String(error.line), maxLengths.line, true) + ':' +
+        padString(String(error.column), maxLengths.column)
+    ) +
+    '  ' + padString(formatSeverity(error.severity), maxLengths.severity) +
+    '  ' + padString(error.message, maxLengths.message) +
+    '  ' + colors.blue(error.ruleId)
+  );
+  return formattedLines.join('\n');
+};
+
 class ESLinter {
   constructor(brunchConfig) {
     this.config = (brunchConfig && brunchConfig.plugins && brunchConfig.plugins.eslint) || {};
@@ -20,11 +54,14 @@ class ESLinter {
     if (errorCount === 0 && warningCount === 0) {
       return Promise.resolve();
     }
-    const errorMsg = result.messages.map(error => {
-      return `${colors.blue(error.message)} (${error.line}:${error.column})`;
-    });
-    errorMsg.unshift(`ESLint detected ${errorCount} ${(pluralize('problem', errorCount))}:`);
-    let msg = errorMsg.join('\n');
+    const problemSummary = [];
+    if (errorCount > 0) {
+      problemSummary.push(errorCount + ' ' + pluralize('error', errorCount));
+    }
+    if (warningCount > 0) {
+      problemSummary.push(warningCount + ' ' + pluralize('warning', warningCount));
+    }
+    let msg = 'ESLint detected ' + problemSummary.join(' and ') + ':\n' + formatErrors(result.messages);
     if (this.warnOnly) {
       msg = `warn: ${msg}`;
     }


### PR DESCRIPTION
fd086cb adds a check for [`warningCount`](http://eslint.org/docs/developer-guide/nodejs-api#executeonfiles) when deciding whether to return a resolved promise (previously, if `errorCount` was zero, then any warnings weren't being reported).

c5a4417 removes some unreachable code.

ad93897 improves the logging format, with a style based on [ESLint's default "stylish" formatter](http://eslint.org/docs/user-guide/formatters/#stylish).
Before:
![before](https://cloud.githubusercontent.com/assets/6292810/18138490/c6302dda-6fa4-11e6-895e-9b2a69d7afb2.png)
After:
![after](https://cloud.githubusercontent.com/assets/6292810/18138513/e9a65816-6fa4-11e6-855c-533a7fb20eb8.png)
