### PR TITLE
Relax the ESLint dependency semver range to include all v3 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# eslint-brunch 3.11.0
+* Uses the latest v3.* release of ESLint
+
 # eslint-brunch 3.10.0
 * Improves the logging format, with a style based on
   [ESLint's default "stylish" formatter](http://eslint.org/docs/user-guide/formatters/#stylish)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "ansicolors": "^0.3.2",
     "pluralize": "~1.2.1",
-    "eslint": "~3.0"
+    "eslint": "^3.0"
   }
 }


### PR DESCRIPTION
The current semver of `~3.0` is very restrictive, only matching [3.0.0](https://github.com/eslint/eslint/releases/tag/v3.0.0) and [3.0.1](https://github.com/eslint/eslint/releases/tag/v3.0.1).

Is there any reason why the semver shouldn't be relaxed to `^3.0` (matching all v3 releases) ?

Looking at ESLint's [release history](https://github.com/eslint/eslint/releases), the project appears to correctly follow the semver requirement that the major version is only incremented for backwards-incompatible breaking API changes.
