### PR TITLE
Use ESLint's formatter for logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,42 +1,6 @@
 'use strict';
 
-const colors = require('ansicolors');
-const pluralize = require('pluralize');
 const CLIEngine = require('eslint').CLIEngine;
-
-var padString = function(input, minLength, right) {
-  var paddingLength = Math.max(0, minLength - input.length);
-  var padding = ' '.repeat(paddingLength);
-  return (right ? (padding + input) : (input + padding));
-};
-
-var formatSeverity = function(severity) {
-  if (severity === 1) {
-    return colors.yellow('warning');
-  }
-  if (severity === 2) {
-    return colors.red('error');
-  }
-  return '';
-};
-
-var formatErrors = function(errors) {
-  var maxLengths = { line: 6, column: 3, severity: 0, message: 0 };
-  errors.forEach((error) => {
-    maxLengths.severity = Math.max(maxLengths.severity, formatSeverity(error.severity).length);
-    maxLengths.message = Math.max(maxLengths.message, error.message.length);
-  });
-  var formattedLines = errors.map((error) =>
-    colors.cyan(
-        padString(String(error.line), maxLengths.line, true) + ':' +
-        padString(String(error.column), maxLengths.column)
-    ) +
-    '  ' + padString(formatSeverity(error.severity), maxLengths.severity) +
-    '  ' + padString(error.message, maxLengths.message) +
-    '  ' + colors.blue(error.ruleId)
-  );
-  return formattedLines.join('\n');
-};
 
 class ESLinter {
   constructor(brunchConfig) {
@@ -48,20 +12,12 @@ class ESLinter {
   }
 
   lint(data, path) {
-    const result = this.linter.executeOnText(data, path).results[0];
-    const errorCount = result.errorCount;
-    const warningCount = result.warningCount;
-    if (errorCount === 0 && warningCount === 0) {
+    const report = this.linter.executeOnText(data, path);
+    if (report.errorCount === 0 && report.warningCount === 0) {
       return Promise.resolve();
     }
-    const problemSummary = [];
-    if (errorCount > 0) {
-      problemSummary.push(errorCount + ' ' + pluralize('error', errorCount));
-    }
-    if (warningCount > 0) {
-      problemSummary.push(warningCount + ' ' + pluralize('warning', warningCount));
-    }
-    let msg = 'ESLint detected ' + problemSummary.join(' and ') + ':\n' + formatErrors(result.messages);
+    const formatter = CLIEngine.getFormatter();
+    let msg = 'ESLint reported:\n' + formatter(report.results);
     if (this.warnOnly) {
       msg = `warn: ${msg}`;
     }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
     "test": "node_modules/.bin/eslint index.js"
   },
   "dependencies": {
-    "ansicolors": "^0.3.2",
-    "pluralize": "~1.2.1",
     "eslint": "^3.0"
   }
 }


### PR DESCRIPTION
Oh dear! Here's a reminder of why it's a good idea to read [relevant documentation](http://eslint.org/docs/developer-guide/nodejs-api#getformatter) before starting to work on something.

Instead of writing custom code to generate log output which looks similar to ESLint's "stylish" formatter (#13), I should have just... used ESLint's "stylish" formatter :stuck_out_tongue:

This also eliminates two NPM dependencies.
