### PR TITLE
Bump eslint to ^5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "eslint-brunch",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "description": "Adds ESLint support to Brunch.",
   "author": "Aurélien David <adavid@jolicode.com>",
   "homepage": "https://github.com/brunch/eslint-brunch",
   "repository": "brunch/eslint-brunch",
   "dependencies": {
-    "eslint": "^4"
+    "eslint": "^5"
   }
 }


### PR DESCRIPTION
Eslint v5 is now current, also fixes some issues related to airbnb configs.